### PR TITLE
Feature/user #1

### DIFF
--- a/src/main/java/com/example/new_instagram_server/user/adapter/in/UserController.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/in/UserController.java
@@ -1,5 +1,7 @@
 package com.example.new_instagram_server.user.adapter.in;
 
+import com.example.new_instagram_server.user.adapter.in.dto.UserDeleteRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserRegisterRequestDto;
 import com.example.new_instagram_server.user.adapter.out.UserRegisterResponseDto;
 import com.example.new_instagram_server.user.application.port.in.UserRegisterUseCase;
 import lombok.RequiredArgsConstructor;
@@ -21,4 +23,13 @@ public class UserController {
     public UserRegisterResponseDto signUp(@ModelAttribute @Valid UserRegisterRequestDto userRegisterRequestDto) {
         return userRegisterUseCase.signUp(userRegisterRequestDto);
     }
+
+    // 회원 탈퇴
+    @DeleteMapping("/profile")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteUser(@RequestBody @Valid UserDeleteRequestDto userDeleteRequestDto) {
+        userRegisterUseCase.deleteUser(userDeleteRequestDto);
+    }
+
+    // 로그인
 }

--- a/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserDeleteRequestDto.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserDeleteRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.new_instagram_server.user.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class UserDeleteRequestDto {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "비밀번호를 다시 한 번 입력해주세요.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserRegisterRequestDto.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserRegisterRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.new_instagram_server.user.adapter.in;
+package com.example.new_instagram_server.user.adapter.in.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserRegisterRequestDto.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/in/dto/UserRegisterRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.new_instagram_server.user.adapter.in;
+package com.example.new_instagram_server.user.adapter.in.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,8 +11,11 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserRegisterRequestDto {
-    @NotBlank(message = "사용할 닉네임을 입력해주세요.")
+    @NotBlank(message = "사용할 아이디를 입력해주세요.")
     private String nickname;
+
+    @NotBlank(message = "사용할 비밀번호를 입력해주세요.")
+    private String password;
 
     private MultipartFile profile_image;
 }

--- a/src/main/java/com/example/new_instagram_server/user/adapter/out/GetAuthenticationImpl.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/out/GetAuthenticationImpl.java
@@ -1,0 +1,12 @@
+package com.example.new_instagram_server.user.adapter.out;
+
+import com.example.new_instagram_server.user.application.port.out.GetAuthentication;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class GetAuthenticationImpl implements GetAuthentication {
+    @Override
+    public Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}

--- a/src/main/java/com/example/new_instagram_server/user/adapter/out/UserRegisterUseCaseImpl.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/out/UserRegisterUseCaseImpl.java
@@ -1,6 +1,7 @@
 package com.example.new_instagram_server.user.adapter.out;
 
-import com.example.new_instagram_server.user.adapter.in.UserRegisterRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserDeleteRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserRegisterRequestDto;
 import com.example.new_instagram_server.user.application.port.in.UserRegisterUseCase;
 import com.example.new_instagram_server.user.application.port.service.UserRegisterService;
 import lombok.RequiredArgsConstructor;
@@ -13,5 +14,10 @@ public class UserRegisterUseCaseImpl implements UserRegisterUseCase {
     public UserRegisterResponseDto signUp(UserRegisterRequestDto userRegisterRequestDto) {
         // 인터페이스를 의존
         return userRegisterService.signUp(userRegisterRequestDto);
+    }
+
+    @Override
+    public void deleteUser(UserDeleteRequestDto userDeleteRequestDto) {
+        userRegisterService.deleteUser(userDeleteRequestDto);
     }
 }

--- a/src/main/java/com/example/new_instagram_server/user/adapter/out/UserRepositoryImpl.java
+++ b/src/main/java/com/example/new_instagram_server/user/adapter/out/UserRepositoryImpl.java
@@ -1,17 +1,32 @@
 package com.example.new_instagram_server.user.adapter.out;
 
+import com.example.new_instagram_server.user.application.port.out.UserJpaRepository;
 import com.example.new_instagram_server.user.application.port.out.UserRepository;
+import com.example.new_instagram_server.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 // UserRepository 를 구현하는 구현체이다.
 // User 데이터베이스와 연관된 작업을 여기서 처리한다.
 @RequiredArgsConstructor
-public class UserRepositoryImpl<T> implements UserRepository<T> {
-    private final JpaRepository<T, Long> jpaRepository;
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository jpaRepository;
 
     @Override
-    public void save(T entity) {
-        jpaRepository.save(entity);
+    public void save(User user) {
+        jpaRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findByNickname(String nickname) {
+        return jpaRepository.findByNickname();
+    }
+
+    @Override
+    public void delete(User user) {
+        jpaRepository.delete(user);
     }
 }

--- a/src/main/java/com/example/new_instagram_server/user/advice/UserExceptionHandler.java
+++ b/src/main/java/com/example/new_instagram_server/user/advice/UserExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.example.new_instagram_server.user.advice;
+
+import com.example.new_instagram_server.user.advice.exception.LoginTimeOutException;
+import com.example.new_instagram_server.user.advice.exception.PasswordMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class UserExceptionHandler {
+    @ExceptionHandler(LoginTimeOutException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String loginTimeOutException() {
+        return "다시 로그인해 주세요.";
+    }
+
+    @ExceptionHandler(PasswordMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String passwordMismatchException() {
+        return "비밀번호가 일치하지 않습니다.";
+    }
+}

--- a/src/main/java/com/example/new_instagram_server/user/advice/exception/LoginTimeOutException.java
+++ b/src/main/java/com/example/new_instagram_server/user/advice/exception/LoginTimeOutException.java
@@ -1,0 +1,4 @@
+package com.example.new_instagram_server.user.advice.exception;
+
+public class LoginTimeOutException extends RuntimeException{
+}

--- a/src/main/java/com/example/new_instagram_server/user/advice/exception/PasswordMismatchException.java
+++ b/src/main/java/com/example/new_instagram_server/user/advice/exception/PasswordMismatchException.java
@@ -1,0 +1,4 @@
+package com.example.new_instagram_server.user.advice.exception;
+
+public class PasswordMismatchException extends RuntimeException{
+}

--- a/src/main/java/com/example/new_instagram_server/user/application/port/in/UserRegisterUseCase.java
+++ b/src/main/java/com/example/new_instagram_server/user/application/port/in/UserRegisterUseCase.java
@@ -1,9 +1,11 @@
 package com.example.new_instagram_server.user.application.port.in;
 
-import com.example.new_instagram_server.user.adapter.in.UserRegisterRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserDeleteRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserRegisterRequestDto;
 import com.example.new_instagram_server.user.adapter.out.UserRegisterResponseDto;
 
 // 고수준 모듈과 저수준 모듈의 의존 역전을 위한 인터페이스 설계
 public interface UserRegisterUseCase {
     UserRegisterResponseDto signUp(UserRegisterRequestDto userRegisterRequestDto);
+    void deleteUser(UserDeleteRequestDto userDeleteRequestDto);
 }

--- a/src/main/java/com/example/new_instagram_server/user/application/port/out/GetAuthentication.java
+++ b/src/main/java/com/example/new_instagram_server/user/application/port/out/GetAuthentication.java
@@ -1,0 +1,7 @@
+package com.example.new_instagram_server.user.application.port.out;
+
+import org.springframework.security.core.Authentication;
+
+public interface GetAuthentication {
+    Authentication getAuthentication();
+}

--- a/src/main/java/com/example/new_instagram_server/user/application/port/out/UserJpaRepository.java
+++ b/src/main/java/com/example/new_instagram_server/user/application/port/out/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package com.example.new_instagram_server.user.application.port.out;
+
+import com.example.new_instagram_server.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    Optional<User> findByNickname();
+}

--- a/src/main/java/com/example/new_instagram_server/user/application/port/out/UserRepository.java
+++ b/src/main/java/com/example/new_instagram_server/user/application/port/out/UserRepository.java
@@ -1,9 +1,16 @@
 package com.example.new_instagram_server.user.application.port.out;
 
+import com.example.new_instagram_server.user.domain.User;
+
+import java.util.Optional;
+
 // 데이터베이스에 대한 인터페이스를 커스텀(queryDSL)할 경우 구현체는 어댑터 out 패키지에 생성한다.
 // 의존 역전을 위해 UserRepositoryImpl 클래스가 UserRepository 를 구현시킨다.
 // UserRepository 의 경우 도메인 명칭인 User 이외 다른 명칭이 쓰일 일은 없지만, 제네릭의 사용으로 다른 경우 모든 상황에 유연하게
 // 대응할 수 있다는 장점이 있다.
-public interface UserRepository<T> {
-    void save(T entity); // 데이터 베이스에 저장
+public interface UserRepository {
+    void save(User user); // 데이터 베이스에 저장
+
+    Optional<User> findByNickname(String nickname);
+    void delete(User user);
 }

--- a/src/main/java/com/example/new_instagram_server/user/application/port/service/UserRegisterService.java
+++ b/src/main/java/com/example/new_instagram_server/user/application/port/service/UserRegisterService.java
@@ -1,8 +1,12 @@
 package com.example.new_instagram_server.user.application.port.service;
 
-import com.example.new_instagram_server.user.adapter.in.UserRegisterRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserDeleteRequestDto;
+import com.example.new_instagram_server.user.adapter.in.dto.UserRegisterRequestDto;
 import com.example.new_instagram_server.user.adapter.out.UserRegisterResponseDto;
+import com.example.new_instagram_server.user.advice.exception.LoginTimeOutException;
+import com.example.new_instagram_server.user.advice.exception.PasswordMismatchException;
 import com.example.new_instagram_server.user.application.port.in.UserRegisterUseCase;
+import com.example.new_instagram_server.user.application.port.out.GetAuthentication;
 import com.example.new_instagram_server.user.domain.User;
 import com.example.new_instagram_server.user.domain.UserRoleType;
 import com.example.new_instagram_server.user.application.port.out.UserRepository;
@@ -13,17 +17,38 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserRegisterService implements UserRegisterUseCase {
-    private final UserRepository<User> userRepository; // 데이터베이스를 상호작용하는 인터페이스를 의존
+    private final UserRepository userRepository; // 데이터베이스를 상호작용하는 인터페이스를 의존
+    private final GetAuthentication getAuthentication; // 토큰정보 상호작용
 
     // 회원가입 로직 설계
     @Override
     public UserRegisterResponseDto signUp(UserRegisterRequestDto userRegisterRequestDto) {
         User newUser = User.builder()
                 .nickname(userRegisterRequestDto.getNickname())
+                .password(userRegisterRequestDto.getPassword())
                 .profile_image_url(userRegisterRequestDto.getProfile_image().getOriginalFilename())
                 .role(UserRoleType.ROLE_MEMBER)
                 .build();
         userRepository.save(newUser);
         return new UserRegisterResponseDto().toDo(newUser);
+    }
+
+    // 회원 탈퇴 로직 설계
+    @Override
+    public void deleteUser(UserDeleteRequestDto userDeleteRequestDto) {
+        // 입력된 두 비밀번호가 같은지 확인한다.
+        if(!userDeleteRequestDto.getPassword().equals(userDeleteRequestDto.getConfirmPassword())) {
+            throw new PasswordMismatchException();
+        }
+        // 현재 로그인한 아이디 정보를 가져온다.
+        User user = userRepository.findByNickname(getAuthentication.getAuthentication().getName()).orElseThrow(() -> {
+            throw new LoginTimeOutException();
+        });
+        // 계정 삭제를 위해 입력한 비밀번호와 계정의 비밀번호가 맞는지 비교한다.
+        if(user.getPassword().equals(userDeleteRequestDto.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+        // 비밀번호가 일치한다면 삭제를 진행한다.
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/example/new_instagram_server/user/domain/User.java
+++ b/src/main/java/com/example/new_instagram_server/user/domain/User.java
@@ -19,6 +19,9 @@ public class User {
     private long id;
 
     @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
     private String nickname;
 
     @Column(nullable = false)


### PR DESCRIPTION
내용
- 회원가입시 로그인 정보를 토큰 정보로 얻어올 수 있도록 수정
- 로그인 후 회원 탈퇴하는 과정을 계정 아이디와 비밀번호 일치 여부로 진행
- 비밀번호는 2번 입력받고 재확인 절차를 거침
- 토큰 정보가 만료되면 로그아웃 상태로 인식하고 재 로그인 요구
- 입력받은 비밀번호 혹은 입력받은 비밀번호와 DB의 비밀번호 정보가 다르면 예외처리

개선 사항
- 비밀번호를 암호화 하는 과정 추가